### PR TITLE
Refactor: 관리자 상품 수정 DTO 생성 (#123)

### DIFF
--- a/src/main/java/com/jelly/zzirit/domain/adminItem/controller/AdminItemController.java
+++ b/src/main/java/com/jelly/zzirit/domain/adminItem/controller/AdminItemController.java
@@ -86,11 +86,14 @@ public class AdminItemController {
 	/**
 	 * (관리자) 상품 수정
 	 */
-	@Operation(summary = "관리자 상품 수정", description = "관리자가 id로 상품을 수정합니다.")
+	@Operation(summary = "관리자 상품 수정", description = "관리자가 id로 상품(재고, 가격)을 수정합니다.")
 	@PutMapping("/{itemId}")
-	public BaseResponse<Empty> updateItem(@PathVariable @NotNull Long itemId, @RequestBody @Valid ItemUpdateRequest request) {
+	public BaseResponse<Empty> updateItem(
+		@PathVariable @NotNull Long itemId,
+		@RequestBody @Valid ItemUpdateRequest request
+	) {
 		return BaseResponse.success(
-				commandAdminItemService.updateItem(itemId, request)
+			commandAdminItemService.updateItem(itemId, request)
 		);
 	}
 

--- a/src/main/java/com/jelly/zzirit/domain/adminItem/controller/AdminItemController.java
+++ b/src/main/java/com/jelly/zzirit/domain/adminItem/controller/AdminItemController.java
@@ -3,6 +3,7 @@ package com.jelly.zzirit.domain.adminItem.controller;
 import java.io.IOException;
 import java.util.List;
 
+import com.jelly.zzirit.domain.adminItem.dto.request.ItemUpdateRequest;
 import com.jelly.zzirit.domain.adminItem.service.CommandAdminItemService;
 import com.jelly.zzirit.domain.adminItem.service.QueryAdminItemService;
 import com.jelly.zzirit.domain.adminItem.service.S3Service;
@@ -87,7 +88,7 @@ public class AdminItemController {
 	 */
 	@Operation(summary = "관리자 상품 수정", description = "관리자가 id로 상품을 수정합니다.")
 	@PutMapping("/{itemId}")
-	public BaseResponse<Empty> updateItem(@PathVariable @NotNull Long itemId, @RequestBody @Valid ItemCreateRequest request) {
+	public BaseResponse<Empty> updateItem(@PathVariable @NotNull Long itemId, @RequestBody @Valid ItemUpdateRequest request) {
 		return BaseResponse.success(
 				commandAdminItemService.updateItem(itemId, request)
 		);

--- a/src/main/java/com/jelly/zzirit/domain/adminItem/dto/request/ItemUpdateRequest.java
+++ b/src/main/java/com/jelly/zzirit/domain/adminItem/dto/request/ItemUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.jelly.zzirit.domain.adminItem.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+import java.math.BigDecimal;
+
+public record ItemUpdateRequest(
+	@NotBlank String name,
+	@PositiveOrZero int stockQuantity,
+	@PositiveOrZero BigDecimal price,
+	@NotNull Long typeId,
+	@NotNull Long brandId
+) {}

--- a/src/main/java/com/jelly/zzirit/domain/adminItem/dto/request/ItemUpdateRequest.java
+++ b/src/main/java/com/jelly/zzirit/domain/adminItem/dto/request/ItemUpdateRequest.java
@@ -1,15 +1,8 @@
 package com.jelly.zzirit.domain.adminItem.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PositiveOrZero;
-
 import java.math.BigDecimal;
 
 public record ItemUpdateRequest(
-	@NotBlank String name,
-	@PositiveOrZero int stockQuantity,
-	@PositiveOrZero BigDecimal price,
-	@NotNull Long typeId,
-	@NotNull Long brandId
+	Integer stockQuantity,
+	BigDecimal price
 ) {}

--- a/src/main/java/com/jelly/zzirit/domain/adminItem/service/CommandAdminItemService.java
+++ b/src/main/java/com/jelly/zzirit/domain/adminItem/service/CommandAdminItemService.java
@@ -1,6 +1,7 @@
 package com.jelly.zzirit.domain.adminItem.service;
 
 import com.jelly.zzirit.domain.adminItem.dto.request.ItemCreateRequest;
+import com.jelly.zzirit.domain.adminItem.dto.request.ItemUpdateRequest;
 import com.jelly.zzirit.domain.item.entity.Item;
 import com.jelly.zzirit.domain.item.entity.TypeBrand;
 import com.jelly.zzirit.domain.item.entity.stock.ItemStock;
@@ -49,23 +50,33 @@ public class CommandAdminItemService {
     }
 
     @Transactional
-    public Empty updateItem(@NotNull Long itemId, ItemCreateRequest request) {
+    public Empty updateItem(@NotNull Long itemId, ItemUpdateRequest request) {
 
         // 상품 조회, dto 보고 타입과 브랜드 조회
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new InvalidItemException(BaseResponseStatus.ITEM_NOT_FOUND));
+
+        String imageUrl = item.getImageUrl();
+
         TypeBrand typeBrand = typeBrandRepository.findByTypeIdAndBrandId(request.typeId(), request.brandId())
-                .orElseThrow(() -> new InvalidItemException(BaseResponseStatus.TYPE_BRAND_NOT_FOUND)); // todo: 예외 처리 괜춘?
+                .orElseThrow(() -> new InvalidItemException(BaseResponseStatus.TYPE_BRAND_NOT_FOUND));
 
-        // 상품 업데이트
-        item.update(request, typeBrand);
+        ItemCreateRequest patchedRequest = new ItemCreateRequest(
+            request.name(),
+            request.stockQuantity(),
+            request.price(),
+            request.typeId(),
+            request.brandId(),
+            imageUrl
+        );
 
-        // 상품 재고 조회
-        ItemStock itemStock = itemStockRepository.findByItemId(itemId)
-            .orElseThrow(() -> new InvalidItemException(BaseResponseStatus.ITEM_STOCK_NOT_FOUND));
+        // 상품 정보 업데이트
+        item.update(patchedRequest, typeBrand);
 
         // 상품 재고 업데이트
-        itemStock.update(request, item);
+        ItemStock itemStock = itemStockRepository.findByItemId(itemId)
+            .orElseThrow(() -> new InvalidItemException(BaseResponseStatus.ITEM_STOCK_NOT_FOUND));
+        itemStock.update(patchedRequest, item);
 
         return Empty.getInstance();
     }

--- a/src/main/java/com/jelly/zzirit/domain/adminItem/service/CommandAdminItemService.java
+++ b/src/main/java/com/jelly/zzirit/domain/adminItem/service/CommandAdminItemService.java
@@ -51,32 +51,19 @@ public class CommandAdminItemService {
 
     @Transactional
     public Empty updateItem(@NotNull Long itemId, ItemUpdateRequest request) {
-
-        // 상품 조회, dto 보고 타입과 브랜드 조회
         Item item = itemRepository.findById(itemId)
-                .orElseThrow(() -> new InvalidItemException(BaseResponseStatus.ITEM_NOT_FOUND));
+            .orElseThrow(() -> new InvalidItemException(BaseResponseStatus.ITEM_NOT_FOUND));
 
-        String imageUrl = item.getImageUrl();
-
-        TypeBrand typeBrand = typeBrandRepository.findByTypeIdAndBrandId(request.typeId(), request.brandId())
-                .orElseThrow(() -> new InvalidItemException(BaseResponseStatus.TYPE_BRAND_NOT_FOUND));
-
-        ItemCreateRequest patchedRequest = new ItemCreateRequest(
-            request.name(),
-            request.stockQuantity(),
-            request.price(),
-            request.typeId(),
-            request.brandId(),
-            imageUrl
-        );
-
-        // 상품 정보 업데이트
-        item.update(patchedRequest, typeBrand);
-
-        // 상품 재고 업데이트
         ItemStock itemStock = itemStockRepository.findByItemId(itemId)
             .orElseThrow(() -> new InvalidItemException(BaseResponseStatus.ITEM_STOCK_NOT_FOUND));
-        itemStock.update(patchedRequest, item);
+
+        if (request.price() != null) {
+            item.changePrice(request.price());
+        }
+
+        if (request.stockQuantity() != null) {
+            itemStock.changeQuantity(request.stockQuantity());
+        }
 
         return Empty.getInstance();
     }

--- a/src/main/java/com/jelly/zzirit/domain/item/entity/Item.java
+++ b/src/main/java/com/jelly/zzirit/domain/item/entity/Item.java
@@ -3,8 +3,10 @@ package com.jelly.zzirit.domain.item.entity;
 import java.math.BigDecimal;
 
 import com.jelly.zzirit.domain.adminItem.dto.request.ItemCreateRequest;
+import com.jelly.zzirit.global.dto.BaseResponseStatus;
 import com.jelly.zzirit.global.dto.Empty;
 import com.jelly.zzirit.global.entity.BaseTime;
+import com.jelly.zzirit.global.exception.custom.InvalidItemException;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -50,6 +52,15 @@ public class Item extends BaseTime {
 		this.name = request.name();
 		this.price = request.price(); // todo: bigdecimal로 변경 필요
 		this.typeBrand = typeBrand;
+
+		return Empty.getInstance();
+	}
+
+	public Empty changePrice(BigDecimal newPrice) {
+		if (newPrice == null || newPrice.compareTo(BigDecimal.ZERO) < 0) {
+			throw new InvalidItemException(BaseResponseStatus.INVALID_PRICE);
+		}
+		this.price = newPrice;
 
 		return Empty.getInstance();
 	}

--- a/src/main/java/com/jelly/zzirit/domain/item/entity/stock/ItemStock.java
+++ b/src/main/java/com/jelly/zzirit/domain/item/entity/stock/ItemStock.java
@@ -51,4 +51,16 @@ public class ItemStock extends BaseEntity {
 	public void addSoldQuantity(int quantity) {
 		this.soldQuantity += quantity;
 	}
+
+	public Empty changeQuantity(int newQuantity) {
+		if (newQuantity < 0) {
+			throw new InvalidItemException(BaseResponseStatus.INVALID_STOCK);
+		}
+		if (this.soldQuantity > newQuantity) {
+			throw new InvalidItemException(BaseResponseStatus.OUT_OF_STOCK);
+		}
+		this.quantity = newQuantity;
+
+		return Empty.getInstance();
+	}
 }

--- a/src/main/java/com/jelly/zzirit/global/dto/BaseResponseStatus.java
+++ b/src/main/java/com/jelly/zzirit/global/dto/BaseResponseStatus.java
@@ -100,7 +100,9 @@ public enum BaseResponseStatus {
 	TYPE_BRAND_NOT_FOUND(false, 60004, "상품 종류-브랜드가 없습니다.", HttpStatus.NOT_FOUND),
 	ITEM_NOT_FOUND_IN_CART(false, 60005, "장바구니에 해당 상품이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 	IMAGE_REQUIRED(false, 60006, "상품 이미지가 없습니다.", HttpStatus.NOT_FOUND),
-	INVALID_IMAGE_URL(false, 60007, "잘못된 이미지 URL 형식입니다.", HttpStatus.BAD_REQUEST);
+	INVALID_IMAGE_URL(false, 60007, "잘못된 이미지 URL 형식입니다.", HttpStatus.BAD_REQUEST),
+	INVALID_PRICE(false, 60008, "상품 가격은 0 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+	INVALID_STOCK(false, 60009, "상품 재고는 0 이상이어야 합니다.", HttpStatus.BAD_REQUEST);
 
 	private final boolean isSuccess;
 	private final int code;


### PR DESCRIPTION
<!-- PR 제목 -> 최종 커밋 메시지로 사용됩니다 -->
<!-- 형식: <타입>: <간결하고 명확한 변경 요약> (#<PR 번호>) -->
<!-- ex) Feat: 로그인 기능 구현 (#123) -->
<!-- 타입 예시: Feat | Fix | Refactor | Docs | Test | Chore -->

## 🐛 관련 이슈
<!--
이 PR로 해결되는 이슈 번호를 Close #번호 형태로 작성해주세요.
예:
- Closes #123
-->
> Closes #123

## 💻 작업 내용
<!--
해당 PR에서 작업한 내용, 변경 사항 등을 작성해주세요.
예:
- 소셜 로그인 기능 추가 (Google, Naver)
- 로그인 예외 처리 방식 수정
- 테스트 코드 보완 및 리팩토링
-->
관리자 상품 수정 DTO 생성
상품 수정할 때 이미지 URL 기존 값 사용합니다
상품 이미지 수정 api는 따로 존재하고 있어요

## ✅ 체크 리스트
<!-- 완료된 항목에 한해서 [ ] 안에 x를 적어주세요. --> 
- [x] 적절한 작업 단위로 커밋을 수행했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 풀 리퀘스트 제목에 컨벤션을 적용했습니다.
- [ ] 테스트 코드를 작성했습니다.
- [x] Assignees에 나를 할당했습니다.

## ⚠️ 주의 사항
<!--
리뷰어가 확인 전에 꼭 알아야 할 변경사항이나 주의사항이 있다면 작성해주세요.
예:
- DB 스키마 변경이 포함되어 있어 배포 전 마이그레이션 필요
- `.env` 설정값이 추가되어야 정상 동작합니다
- 주의 사항이 없을 시: _No specific notes_
-->


## 🗨️ 리뷰 요구 사항
<!--
리뷰어가 중점적으로 확인해줬으면 하는 부분이 있다면 작성해주세요.
예:
- 새로운 정렬 로직의 성능이 괜찮은지 확인 부탁드립니다
- 컨트롤러에서 비즈니스 로직을 얼마나 포함해도 될지 의견 부탁드립니다
- 리뷰 요구 사항이 없을 시: _Nothing in particular_
-->
관리자 상품을 수정할 때 현재 재고와 가격만 수정가능한데 이부분도 맞춰서 수정이 필요할지 확인부탁드려요
상품 수정 dto에서 받는 값이 기존 생성 dto에서 받는 값에 이미지 URL 값만 뺀 상태입니다