### PR TITLE
Refactor: 장바구니 리팩토링 (#165)

### DIFF
--- a/src/main/java/com/jelly/zzirit/domain/cart/mapper/CartItemMapper.java
+++ b/src/main/java/com/jelly/zzirit/domain/cart/mapper/CartItemMapper.java
@@ -9,30 +9,33 @@ import com.jelly.zzirit.domain.item.entity.timedeal.TimeDealItem;
 
 public class CartItemMapper {
 
-	public static CartItemFetchResponse mapToCartItem(CartItem cartItem, ItemStock itemStock,
-		TimeDealItem timeDealItem) {
+	public static CartItemFetchResponse mapToCartItem(CartItem cartItem, ItemStock itemStock, TimeDealItem timeDealItem) {
 		Item item = cartItem.getItem();
 		int quantity = cartItem.getQuantity();
 		int originalPrice = item.getPrice().intValue();
 
-		int discountedPrice = originalPrice;
-		Integer discountRatio = null;
 		boolean isTimeDeal = item.getItemStatus() == ItemStatus.TIME_DEAL;
 
-		if (timeDealItem != null) {
-			discountedPrice = timeDealItem.getPrice().intValue();
-			discountRatio = timeDealItem.getTimeDeal().getDiscountRatio();
-		}
+		int discountedPrice = isTimeDeal
+			? timeDealItem.getPrice().intValue()
+			: originalPrice;
+
+		Integer discountRatio = isTimeDeal
+			? timeDealItem.getTimeDeal().getDiscountRatio()
+			: null;
 
 		int totalPrice = discountedPrice * quantity;
 		boolean isSoldOut = itemStock.getQuantity() == 0;
+
+		String typeName = item.getTypeBrand().getType().getName();
+		String brandName = item.getTypeBrand().getBrand().getName();
 
 		return new CartItemFetchResponse(
 			cartItem.getId(),
 			item.getId(),
 			item.getName(),
-			item.getTypeBrand().getType().getName(),
-			item.getTypeBrand().getBrand().getName(),
+			typeName,
+			brandName,
 			quantity,
 			item.getImageUrl(),
 			originalPrice,

--- a/src/main/java/com/jelly/zzirit/domain/cart/mapper/CartItemMapper.java
+++ b/src/main/java/com/jelly/zzirit/domain/cart/mapper/CartItemMapper.java
@@ -1,0 +1,46 @@
+package com.jelly.zzirit.domain.cart.mapper;
+
+import com.jelly.zzirit.domain.cart.dto.response.CartItemFetchResponse;
+import com.jelly.zzirit.domain.cart.entity.CartItem;
+import com.jelly.zzirit.domain.item.entity.Item;
+import com.jelly.zzirit.domain.item.entity.ItemStatus;
+import com.jelly.zzirit.domain.item.entity.stock.ItemStock;
+import com.jelly.zzirit.domain.item.entity.timedeal.TimeDealItem;
+
+public class CartItemMapper {
+
+	public static CartItemFetchResponse mapToCartItem(CartItem cartItem, ItemStock itemStock,
+		TimeDealItem timeDealItem) {
+		Item item = cartItem.getItem();
+		int quantity = cartItem.getQuantity();
+		int originalPrice = item.getPrice().intValue();
+
+		int discountedPrice = originalPrice;
+		Integer discountRatio = null;
+		boolean isTimeDeal = item.getItemStatus() == ItemStatus.TIME_DEAL;
+
+		if (timeDealItem != null) {
+			discountedPrice = timeDealItem.getPrice().intValue();
+			discountRatio = timeDealItem.getTimeDeal().getDiscountRatio();
+		}
+
+		int totalPrice = discountedPrice * quantity;
+		boolean isSoldOut = itemStock.getQuantity() == 0;
+
+		return new CartItemFetchResponse(
+			cartItem.getId(),
+			item.getId(),
+			item.getName(),
+			item.getTypeBrand().getType().getName(),
+			item.getTypeBrand().getBrand().getName(),
+			quantity,
+			item.getImageUrl(),
+			originalPrice,
+			discountedPrice,
+			totalPrice,
+			isTimeDeal,
+			discountRatio,
+			isSoldOut
+		);
+	}
+}

--- a/src/main/java/com/jelly/zzirit/domain/cart/repository/CartItemQueryRepository.java
+++ b/src/main/java/com/jelly/zzirit/domain/cart/repository/CartItemQueryRepository.java
@@ -1,0 +1,14 @@
+package com.jelly.zzirit.domain.cart.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.jelly.zzirit.domain.cart.entity.CartItem;
+
+public interface CartItemQueryRepository {
+
+	List<CartItem> findAllWithItemByCartId(Long cartId);
+
+	Optional<CartItem> findWithItemJoinByCartIdAndItemId(Long cartId, Long itemId);
+
+}

--- a/src/main/java/com/jelly/zzirit/domain/cart/repository/CartItemQueryRepositoryImpl.java
+++ b/src/main/java/com/jelly/zzirit/domain/cart/repository/CartItemQueryRepositoryImpl.java
@@ -9,12 +9,17 @@ import static com.jelly.zzirit.domain.item.entity.QTypeBrand.*;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.jelly.zzirit.domain.cart.entity.CartItem;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
+@Repository
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CartItemQueryRepositoryImpl implements CartItemQueryRepository {
 
 	private final JPAQueryFactory queryFactory;

--- a/src/main/java/com/jelly/zzirit/domain/cart/repository/CartItemQueryRepositoryImpl.java
+++ b/src/main/java/com/jelly/zzirit/domain/cart/repository/CartItemQueryRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.jelly.zzirit.domain.cart.repository;
+
+import static com.jelly.zzirit.domain.cart.entity.QCartItem.*;
+import static com.jelly.zzirit.domain.item.entity.QBrand.*;
+import static com.jelly.zzirit.domain.item.entity.QItem.*;
+import static com.jelly.zzirit.domain.item.entity.QType.*;
+import static com.jelly.zzirit.domain.item.entity.QTypeBrand.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.jelly.zzirit.domain.cart.entity.CartItem;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CartItemQueryRepositoryImpl implements CartItemQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<CartItem> findAllWithItemByCartId(Long cartId) {
+		return queryFactory
+			.selectFrom(cartItem)
+			.join(cartItem.item, item).fetchJoin()
+			.join(item.typeBrand, typeBrand).fetchJoin()
+			.join(typeBrand.type, type).fetchJoin()
+			.join(typeBrand.brand, brand).fetchJoin()
+			.where(cartItem.cart.id.eq(cartId))
+			.fetch();
+	}
+
+	@Override
+	public Optional<CartItem> findWithItemJoinByCartIdAndItemId(Long cartId, Long itemId) {
+		return Optional.ofNullable(queryFactory
+			.selectFrom(cartItem)
+			.join(cartItem.item, item).fetchJoin()
+			.join(item.typeBrand, typeBrand).fetchJoin()
+			.join(typeBrand.type, type).fetchJoin()
+			.join(typeBrand.brand, brand).fetchJoin()
+			.where(cartItem.cart.id.eq(cartId), cartItem.item.id.eq(itemId))
+			.fetchOne());
+	}
+}

--- a/src/main/java/com/jelly/zzirit/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/jelly/zzirit/domain/cart/repository/CartItemRepository.java
@@ -7,9 +7,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.jelly.zzirit.domain.cart.entity.CartItem;
 
-public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+public interface CartItemRepository extends JpaRepository<CartItem, Long>, CartItemQueryRepository {
 
 	List<CartItem> findAllByCartId(Long cartId);
 
 	Optional<CartItem> findByCartIdAndItemId(Long cartId, Long itemId);
+
 }

--- a/src/main/java/com/jelly/zzirit/domain/cart/service/CartItemService.java
+++ b/src/main/java/com/jelly/zzirit/domain/cart/service/CartItemService.java
@@ -18,6 +18,7 @@ import com.jelly.zzirit.domain.item.repository.ItemQueryRepository;
 import com.jelly.zzirit.domain.item.repository.ItemStockRepository;
 import com.jelly.zzirit.domain.item.repository.TimeDealItemRepository;
 import com.jelly.zzirit.domain.member.entity.Member;
+import com.jelly.zzirit.domain.member.repository.MemberRepository;
 import com.jelly.zzirit.global.dto.BaseResponseStatus;
 import com.jelly.zzirit.global.exception.custom.InvalidItemException;
 import com.jelly.zzirit.global.exception.custom.InvalidUserException;
@@ -30,6 +31,7 @@ public class CartItemService {
 
 	private final CartRepository cartRepository;
 	private final CartItemRepository cartItemRepository;
+	private final MemberRepository memberRepository;
 	private final ItemQueryRepository itemQueryRepository;
 	private final ItemStockRepository itemStockRepository;
 	private final TimeDealItemRepository timeDealItemRepository;
@@ -92,7 +94,8 @@ public class CartItemService {
 	private Cart getOrCreateCart(Long memberId) {
 		return cartRepository.findByMemberId(memberId)
 			.orElseGet(() -> {
-				Member member = Member.builder().id(memberId).build();
+				Member member = memberRepository.findById(memberId)
+					.orElseThrow(() -> new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND));
 				return cartRepository.save(Cart.builder().member(member).build());
 			});
 	}

--- a/src/main/java/com/jelly/zzirit/domain/cart/service/CartItemService.java
+++ b/src/main/java/com/jelly/zzirit/domain/cart/service/CartItemService.java
@@ -106,7 +106,7 @@ public class CartItemService {
 		Cart cart = cartRepository.findByMemberId(memberId)
 			.orElseThrow(() -> new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND));
 
-		CartItem cartItem = cartItemRepository.findByCartIdAndItemId(cart.getId(), itemId)
+		CartItem cartItem = cartItemRepository.findWithItemJoinByCartIdAndItemId(cart.getId(), itemId)
 			.orElseThrow(() -> new InvalidItemException(BaseResponseStatus.ITEM_NOT_FOUND_IN_CART));
 
 		int newQuantity = cartItem.getQuantity() + delta;

--- a/src/main/java/com/jelly/zzirit/domain/cart/service/CartService.java
+++ b/src/main/java/com/jelly/zzirit/domain/cart/service/CartService.java
@@ -76,7 +76,7 @@ public class CartService {
 				Item item = cartItem.getItem();
 				ItemStock itemStock = stockMap.get(item.getId());
 				if (itemStock == null) {
-					throw new InvalidItemException(BaseResponseStatus.ITEM_NOT_FOUND);
+					throw new InvalidItemException(BaseResponseStatus.ITEM_STOCK_NOT_FOUND);
 				}
 
 				TimeDealItem timeDealItem = item.getItemStatus() == ItemStatus.TIME_DEAL

--- a/src/main/java/com/jelly/zzirit/domain/item/infra/persist/ItemQueryRepositoryImpl.java
+++ b/src/main/java/com/jelly/zzirit/domain/item/infra/persist/ItemQueryRepositoryImpl.java
@@ -6,6 +6,7 @@ import static com.jelly.zzirit.domain.item.entity.QType.*;
 import static com.jelly.zzirit.domain.item.entity.QTypeBrand.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -62,6 +63,18 @@ public class ItemQueryRepositoryImpl implements ItemQueryRepository {
 				pageable,
 				total::fetchOne
 			);
+	}
+
+	@Override
+	public Optional<Item> findItemWithTypeJoin(Long itemId) {
+		return Optional.ofNullable(
+			queryFactory.selectFrom(item)
+				.join(item.typeBrand, typeBrand).fetchJoin()
+				.join(typeBrand.type, type).fetchJoin()
+				.join(typeBrand.brand, brand).fetchJoin()
+				.where(item.id.eq(itemId))
+				.fetchOne()
+		);
 	}
 
 	private OrderSpecifier<?> sortByPrice(String sort) {

--- a/src/main/java/com/jelly/zzirit/domain/item/repository/ItemQueryRepository.java
+++ b/src/main/java/com/jelly/zzirit/domain/item/repository/ItemQueryRepository.java
@@ -1,6 +1,7 @@
 package com.jelly.zzirit.domain.item.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,4 +17,6 @@ public interface ItemQueryRepository {
 		String sort,
 		Pageable pageable
 	);
+
+	Optional<Item> findItemWithTypeJoin(Long itemId);
 }

--- a/src/main/java/com/jelly/zzirit/global/config/securityconfig/SecurityConfig.java
+++ b/src/main/java/com/jelly/zzirit/global/config/securityconfig/SecurityConfig.java
@@ -92,9 +92,7 @@ public class SecurityConfig {
 					"/v3/api-docs/**",
 					"/favicon.ico"
 				).permitAll()
-				.requestMatchers("/api/admin/item/**").hasRole(Role.ROLE_ADMIN.getKey())
-				.requestMatchers("/api/time-deals/**").permitAll() // 수정 필요
-				.requestMatchers("/api/cart/**").authenticated()
+				.requestMatchers("/api/admin/**").hasRole(Role.ROLE_ADMIN.getKey())
 				.anyRequest().authenticated()
 			);
 

--- a/src/test/java/com/jelly/zzirit/domain/cart/controller/CartControllerTest.java
+++ b/src/test/java/com/jelly/zzirit/domain/cart/controller/CartControllerTest.java
@@ -33,31 +33,14 @@ import com.jelly.zzirit.global.support.OpenApiDocumentationFilter;
 
 class CartControllerTest extends AcceptanceTest {
 
-
-	@Autowired
-	private CartItemRepository cartItemRepository;
-
-	@Autowired
-	private CartRepository cartRepository;
-
-	@Autowired
-	private MemberRepository memberRepository;
-
-	@Autowired
-	private ItemRepository itemRepository;
-
-	@Autowired
-	private BrandRepository brandRepository;
-
-	@Autowired
-	private TypeRepository typeRepository;
-
-	@Autowired
-	private TypeBrandRepository typeBrandRepository;
-
-	@Autowired
-	private ItemStockRepository itemStockRepository;
-
+	@Autowired private CartItemRepository cartItemRepository;
+	@Autowired private CartRepository cartRepository;
+	@Autowired private MemberRepository memberRepository;
+	@Autowired private ItemRepository itemRepository;
+	@Autowired private BrandRepository brandRepository;
+	@Autowired private TypeRepository typeRepository;
+	@Autowired private TypeBrandRepository typeBrandRepository;
+	@Autowired private ItemStockRepository itemStockRepository;
 
 	@Test
 	void 장바구니_조회() {

--- a/src/test/java/com/jelly/zzirit/domain/cart/controller/CartItemControllerTest.java
+++ b/src/test/java/com/jelly/zzirit/domain/cart/controller/CartItemControllerTest.java
@@ -35,22 +35,14 @@ import com.jelly.zzirit.global.support.OpenApiDocumentationFilter;
 
 class CartItemControllerTest extends AcceptanceTest {
 
-	@Autowired
-	private MemberRepository memberRepository;
-	@Autowired
-	private TypeRepository typeRepository;
-	@Autowired
-	private BrandRepository brandRepository;
-	@Autowired
-	private TypeBrandRepository typeBrandRepository;
-	@Autowired
-	private ItemRepository itemRepository;
-	@Autowired
-	private ItemStockRepository itemStockRepository;
-	@Autowired
-	private CartRepository cartRepository;
-	@Autowired
-	private CartItemRepository cartItemRepository;
+	@Autowired private MemberRepository memberRepository;
+	@Autowired private TypeRepository typeRepository;
+	@Autowired private BrandRepository brandRepository;
+	@Autowired private TypeBrandRepository typeBrandRepository;
+	@Autowired private ItemRepository itemRepository;
+	@Autowired private ItemStockRepository itemStockRepository;
+	@Autowired private CartRepository cartRepository;
+	@Autowired private CartItemRepository cartItemRepository;
 
 	private Long itemId;
 

--- a/src/test/java/com/jelly/zzirit/domain/cart/service/CartItemServiceTest.java
+++ b/src/test/java/com/jelly/zzirit/domain/cart/service/CartItemServiceTest.java
@@ -7,7 +7,6 @@ import java.math.BigDecimal;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,7 +27,7 @@ import com.jelly.zzirit.domain.item.entity.TypeBrand;
 import com.jelly.zzirit.domain.item.entity.stock.ItemStock;
 import com.jelly.zzirit.domain.item.entity.timedeal.TimeDeal;
 import com.jelly.zzirit.domain.item.entity.timedeal.TimeDealItem;
-import com.jelly.zzirit.domain.item.repository.ItemRepository;
+import com.jelly.zzirit.domain.item.repository.ItemQueryRepository;
 import com.jelly.zzirit.domain.item.repository.ItemStockRepository;
 import com.jelly.zzirit.domain.item.repository.TimeDealItemRepository;
 import com.jelly.zzirit.domain.member.entity.Member;
@@ -37,237 +36,136 @@ import com.jelly.zzirit.global.exception.custom.InvalidItemException;
 @ExtendWith(MockitoExtension.class)
 class CartItemServiceTest {
 
-	@Mock
-	private CartRepository cartRepository;
-	@Mock
-	private CartItemRepository cartItemRepository;
-	@Mock
-	private ItemRepository itemRepository;
-	@Mock
-	private TimeDealItemRepository timeDealItemRepository;
-	@Mock
-	private ItemStockRepository itemStockRepository;
-	@Mock
-	private CartService cartService;
-
-	@InjectMocks
-	private CartItemService cartItemService;
+	@Mock CartRepository cartRepository;
+	@Mock CartItemRepository cartItemRepository;
+	@Mock ItemQueryRepository itemQueryRepository;
+	@Mock ItemStockRepository itemStockRepository;
+	@Mock TimeDealItemRepository timeDealItemRepository;
+	@InjectMocks CartItemService cartItemService;
 
 	private final Long memberId = 1L;
-
 	private Cart cart;
+	private TypeBrand typeBrand;
 	private Item item;
-	private CartItem cartItem;
 	private ItemStock itemStock;
 
 	@BeforeEach
 	void setUp() {
-		// 아이템 종류와 브랜드 정보 생성
 		Type type = Type.builder().name("노트북").build();
 		Brand brand = Brand.builder().name("Apple").build();
-		TypeBrand typeBrand = TypeBrand.builder()
-			.type(type)
-			.brand(brand)
-			.build();
+		typeBrand = TypeBrand.builder().type(type).brand(brand).build();
 
-		// 테스트용 상품
 		item = Item.builder()
 			.id(10L)
 			.name("MacBook Pro")
 			.price(BigDecimal.valueOf(2000000))
-			.imageUrl("https://dummyimage.com/macbook.jpg")
+			.imageUrl("url")
 			.itemStatus(ItemStatus.NONE)
 			.typeBrand(typeBrand)
 			.build();
 
-		// 상품 재고
-		itemStock = ItemStock.builder()
-			.item(item)
-			.quantity(10)
-			.build();
+		itemStock = ItemStock.builder().item(item).quantity(10).build();
 
-		// 장바구니 생성
-		cart = Cart.builder()
-			.member(Member.builder().id(memberId).build())
-			.build();
+		cart = Cart.builder().member(Member.builder().id(memberId).build()).build();
 		cart.setId(1L);
-
-		// 장바구니 항목
-		cartItem = CartItem.of(cart, item, 1);
-		cartItem.setId(100L);
 	}
 
 	@Test
-	@DisplayName("상품 장바구니 추가")
-	void addNewItem() {
-		// given: 상품 ID와 수량이 담긴 요청 객체를 생성하고,
-		// 장바구니, 상품, 재고가 모두 정상적으로 존재하는 상황을 가정
+	void 장바구니_상품_추가() {
 		CartItemCreateRequest request = new CartItemCreateRequest(item.getId(), 2);
+		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
+		given(itemQueryRepository.findItemWithTypeJoin(item.getId())).willReturn(Optional.of(item));
+		given(cartItemRepository.findByCartIdAndItemId(cart.getId(), item.getId())).willReturn(Optional.empty());
+		given(itemStockRepository.findByItemId(item.getId())).willReturn(Optional.of(itemStock));
 
-		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart)); // 회원의 장바구니 존재
-		given(itemRepository.findById(item.getId())).willReturn(Optional.of(item));   // 상품 존재
-		given(cartItemRepository.findByCartIdAndItemId(cart.getId(), item.getId())).willReturn(Optional.empty()); // 장바구니에 해당 상품 없음
-		given(itemStockRepository.findByItemId(item.getId())).willReturn(Optional.of(itemStock)); // 재고 존재
+		CartItemFetchResponse result = cartItemService.addItemToCart(memberId, request);
 
-		// when: 장바구니 서비스에 상품 추가 요청을 수행
-		CartItemFetchResponse response = cartItemService.addItemToCart(memberId, request);
-
-		// then: 응답 결과가 요청한 상품 ID와 수량을 반영하고, 할인 없이 정가가 적용되며 품절 아님을 검증
-		assertThat(response.itemId()).isEqualTo(item.getId());
-		assertThat(response.quantity()).isEqualTo(2);
-		assertThat(response.discountedPrice()).isEqualTo(2000000); // 정가
-		assertThat(response.totalPrice()).isEqualTo(2000000 * 2);  // 총 가격
-		assertThat(response.isSoldOut()).isFalse();                   // 품절 아님
+		assertThat(result.itemId()).isEqualTo(item.getId());
+		assertThat(result.quantity()).isEqualTo(2);
+		assertThat(result.isSoldOut()).isFalse();
+		assertThat(result.discountedPrice()).isEqualTo(2000000);
+		assertThat(result.totalPrice()).isEqualTo(2000000 * 2);
 	}
 
 	@Test
-	@DisplayName("타임딜 상품 할인 적용")
-	void addTimeDealItem() {
-		// given: 타임딜 상태 상품과 타임딜 정보, 요청, 재고 등 모든 mock 구성
+	void 장바구니_상품_할인() {
 		item.changeItemStatus(ItemStatus.TIME_DEAL);
-
 		TimeDealItem timeDealItem = TimeDealItem.builder()
 			.item(item)
-			.price(BigDecimal.valueOf(1800000)) // 할인 가격
-			.timeDeal(TimeDeal.builder().discountRatio(10).build()) // 할인율
+			.price(BigDecimal.valueOf(1800000))
+			.timeDeal(TimeDeal.builder().discountRatio(10).build())
 			.build();
 
 		CartItemCreateRequest request = new CartItemCreateRequest(item.getId(), 2);
-
 		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
-		given(itemRepository.findById(item.getId())).willReturn(Optional.of(item));
+		given(itemQueryRepository.findItemWithTypeJoin(item.getId())).willReturn(Optional.of(item));
 		given(cartItemRepository.findByCartIdAndItemId(cart.getId(), item.getId())).willReturn(Optional.empty());
 		given(itemStockRepository.findByItemId(item.getId())).willReturn(Optional.of(itemStock));
 		given(timeDealItemRepository.findActiveTimeDealItemByItemId(item.getId())).willReturn(Optional.of(timeDealItem));
 
-		// when: 타임딜 상품 장바구니 추가
-		CartItemFetchResponse response = cartItemService.addItemToCart(memberId, request);
+		CartItemFetchResponse result = cartItemService.addItemToCart(memberId, request);
 
-		// then: 할인 정보가 정확히 반영되어 응답되는지 검증
-		assertThat(response.isTimeDeal()).isTrue();
-		assertThat(response.discountedPrice()).isEqualTo(1800000);
-		assertThat(response.originalPrice()).isEqualTo(2000000);
-		assertThat(response.discountRatio()).isEqualTo(10);
-		assertThat(response.totalPrice()).isEqualTo(1800000 * 2);
+		assertThat(result.isTimeDeal()).isTrue();
+		assertThat(result.discountedPrice()).isEqualTo(1800000);
+		assertThat(result.originalPrice()).isEqualTo(2000000);
+		assertThat(result.discountRatio()).isEqualTo(10);
+		assertThat(result.totalPrice()).isEqualTo(1800000 * 2);
 	}
 
 	@Test
-	@DisplayName("품절 상품 장바구니 추가")
-	void addSoldOutItem() {
-		// given: 재고가 0인 상품과 장바구니 요청 객체, mock 리턴 설정
-		ItemStock soldOutStock = ItemStock.builder()
-			.item(item)
-			.quantity(0)
-			.build();
-
+	void 장바구니_상품_품절() {
+		itemStock = ItemStock.builder().item(item).quantity(0).build();
 		CartItemCreateRequest request = new CartItemCreateRequest(item.getId(), 1);
-
 		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
-		given(itemRepository.findById(item.getId())).willReturn(Optional.of(item));
+		given(itemQueryRepository.findItemWithTypeJoin(item.getId())).willReturn(Optional.of(item));
 		given(cartItemRepository.findByCartIdAndItemId(cart.getId(), item.getId())).willReturn(Optional.empty());
-		given(itemStockRepository.findByItemId(item.getId())).willReturn(Optional.of(soldOutStock));
-
-		// when: 품절 상품을 장바구니에 추가
-		CartItemFetchResponse response = cartItemService.addItemToCart(memberId, request);
-
-		// then: 품절 여부가 true이고 가격 정보는 그대로 반영되었는지 검증
-		assertThat(response.itemId()).isEqualTo(item.getId());
-		assertThat(response.quantity()).isEqualTo(1);
-		assertThat(response.isSoldOut()).isTrue();
-		assertThat(response.discountedPrice()).isEqualTo(2000000); // 정가
-		assertThat(response.totalPrice()).isEqualTo(2000000); // 정가 * 수량
-	}
-
-	@Test
-	@DisplayName("장바구니 상품 삭제")
-	void removeItem() {
-		// given: 장바구니와 해당 상품이 존재하는 상황을 가정
-		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
-		given(cartItemRepository.findByCartIdAndItemId(cart.getId(), item.getId())).willReturn(Optional.of(cartItem));
-
-		// when: 상품 삭제 메서드 실행
-		// then: 예외 없이 실행되고, 실제로 삭제 메서드가 호출되었는지 검증
-		assertThatCode(() -> cartItemService.removeItemToCart(memberId, item.getId()))
-			.doesNotThrowAnyException();
-
-		verify(cartItemRepository).delete(cartItem);
-	}
-
-
-	@Test
-	@DisplayName("장바구니 상품 수량 증가")
-	void increaseItemQuantity() {
-		// given: 장바구니에 해당 상품이 1개 담겨 있는 상태
-		cartItem.setQuantity(1);
-		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
-		given(itemRepository.findById(item.getId())).willReturn(Optional.of(item));
-		given(cartItemRepository.findByCartIdAndItemId(cart.getId(), item.getId())).willReturn(Optional.of(cartItem));
 		given(itemStockRepository.findByItemId(item.getId())).willReturn(Optional.of(itemStock));
 
-		// when: 동일 상품 2개를 addItemToCart로 재추가
-		CartItemCreateRequest request = new CartItemCreateRequest(item.getId(), 2);
-		CartItemFetchResponse responseViaAdd = cartItemService.addItemToCart(memberId, request);
+		CartItemFetchResponse result = cartItemService.addItemToCart(memberId, request);
 
-		// then: 기존 수량 1 + 추가 2 = 총 3이 반영되어야 함
-		assertThat(responseViaAdd.quantity()).isEqualTo(3);
-		assertThat(responseViaAdd.totalPrice()).isEqualTo(responseViaAdd.discountedPrice() * 3);
-		assertThat(responseViaAdd.isSoldOut()).isFalse();
-		verify(cartItemRepository, never()).save(any()); // 기존 항목에 수량만 증가했으므로 save 호출되지 않음
-
-		// when: modifyQuantity를 통해 수량을 +1 증가
-		CartItemFetchResponse responseViaModify = cartItemService.modifyQuantity(memberId, item.getId(), +1);
-
-		// then: 총 수량 4가 반영되어야 함
-		assertThat(responseViaModify.quantity()).isEqualTo(4);
-		assertThat(responseViaModify.totalPrice()).isEqualTo(responseViaModify.discountedPrice() * 4);
+		assertThat(result.isSoldOut()).isTrue();
+		assertThat(result.totalPrice()).isEqualTo(item.getPrice().intValue());
 	}
 
 	@Test
-	@DisplayName("장바구니 수량 감소")
-	void decreaseItemQuantity() {
-		// given: 초기 수량이 3인 상태에서 수량 감소 요청
-		cartItem.setQuantity(3);
+	void 장바구니_상품_증감() {
+		CartItem cartItem = CartItem.of(cart, item, 2);
 		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
-		given(cartItemRepository.findByCartIdAndItemId(cart.getId(), item.getId())).willReturn(Optional.of(cartItem));
+		given(cartItemRepository.findWithItemJoinByCartIdAndItemId(cart.getId(), item.getId())).willReturn(Optional.of(cartItem));
 		given(itemStockRepository.findByItemId(item.getId())).willReturn(Optional.of(itemStock));
 
-		// when: 수량 1 감소 요청
-		CartItemFetchResponse result = cartItemService.modifyQuantity(memberId, item.getId(), -1);
+		CartItemFetchResponse increased = cartItemService.modifyQuantity(memberId, item.getId(), +1);
+		assertThat(increased.quantity()).isEqualTo(3);
 
-		// then: 수량이 2로 줄고 총 가격이 할인 가격 * 2로 계산되는지 검증
-		assertThat(cartItem.getQuantity()).isEqualTo(2);
-		assertThat(result).isNotNull();
-		assertThat(result.quantity()).isEqualTo(2);
-		assertThat(result.totalPrice()).isEqualTo(result.discountedPrice() * 2);
+		CartItemFetchResponse decreased = cartItemService.modifyQuantity(memberId, item.getId(), -2);
+		assertThat(decreased.quantity()).isEqualTo(1);
 	}
 
 	@Test
-	@DisplayName("장바구니 수량 0 예외")
-	void decreaseToZero_throws() {
-		// given: 수량이 1인 상품이 장바구니에 담긴 상태
-		cartItem.setQuantity(1);
-		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
-		given(cartItemRepository.findByCartIdAndItemId(cart.getId(), item.getId())).willReturn(Optional.of(cartItem));
+	void 장바구니_상품_수량_예외() {
+		CartItem cartItem = CartItem.of(cart, item, 1);
+		itemStock = ItemStock.builder().item(item).quantity(1).build();
 
-		// when / then: 수량 -1 요청 시 예외 발생 확인
+		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
+		given(cartItemRepository.findWithItemJoinByCartIdAndItemId(cart.getId(), item.getId())).willReturn(Optional.of(cartItem));
+		given(itemStockRepository.findByItemId(item.getId())).willReturn(Optional.of(itemStock));
+
 		assertThatThrownBy(() -> cartItemService.modifyQuantity(memberId, item.getId(), -1))
 			.isInstanceOf(InvalidItemException.class)
-			.hasMessageContaining("장바구니 수량은 1개 이상이어야 합니다.");
+			.hasMessageContaining("장바구니 수량은 1개 이상");
+
+		assertThatThrownBy(() -> cartItemService.modifyQuantity(memberId, item.getId(), +1))
+			.isInstanceOf(InvalidItemException.class)
+			.hasMessageContaining("장바구니 수량이 재고를 초과");
 	}
 
 	@Test
-	@DisplayName("재고 초과 예외")
-	void increaseOverStock_throws() {
-		// given: 현재 수량과 재고가 동일한 상태에서 수량을 추가하려는 요청
-		cartItem.setQuantity(10);
-		itemStock = ItemStock.builder().item(item).quantity(10).build(); // 재고 = 10
+	void 장바구니_상품_삭제() {
+		CartItem cartItem = CartItem.of(cart, item, 1);
 		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
 		given(cartItemRepository.findByCartIdAndItemId(cart.getId(), item.getId())).willReturn(Optional.of(cartItem));
-		given(itemStockRepository.findByItemId(item.getId())).willReturn(Optional.of(itemStock));
 
-		// when / then: 수량 +1 요청 시 재고 초과로 예외 발생 확인
-		assertThatThrownBy(() -> cartItemService.modifyQuantity(memberId, item.getId(), +1))
-			.isInstanceOf(InvalidItemException.class)
-			.hasMessageContaining("장바구니 수량이 재고를 초과할 수 없습니다.");
+		assertThatCode(() -> cartItemService.removeItemToCart(memberId, item.getId())).doesNotThrowAnyException();
+		verify(cartItemRepository).delete(cartItem);
 	}
 }

--- a/src/test/java/com/jelly/zzirit/domain/cart/service/CartServiceTest.java
+++ b/src/test/java/com/jelly/zzirit/domain/cart/service/CartServiceTest.java
@@ -36,235 +36,140 @@ import com.jelly.zzirit.domain.member.entity.Member;
 @ExtendWith(MockitoExtension.class)
 class CartServiceTest {
 
-	@Mock
-	private CartRepository cartRepository;
-
-	@Mock
-	private CartItemRepository cartItemRepository;
-
-	@Mock
-	private TimeDealItemRepository timeDealItemRepository;
-
-	@Mock
-	private ItemStockRepository itemStockRepository;
-
-	@InjectMocks
-	private CartService cartService;
+	@Mock private CartRepository cartRepository;
+	@Mock private CartItemRepository cartItemRepository;
+	@Mock private TimeDealItemRepository timeDealItemRepository;
+	@Mock private ItemStockRepository itemStockRepository;
+	@InjectMocks private CartService cartService;
 
 	private final Long memberId = 1L;
 	private Cart cart;
-	private Item item;
-	private CartItem cartItem;
-	private ItemStock itemStock;
+	private TypeBrand sharedTypeBrand;
 
 	@BeforeEach
 	void setUp() {
-		// 아이템 종류와 브랜드 정보 생성
 		Type type = Type.builder().name("스마트폰").build();
 		Brand brand = Brand.builder().name("Apple").build();
-		TypeBrand typeBrand = TypeBrand.builder()
-			.type(type)
-			.brand(brand)
-			.build();
+		sharedTypeBrand = TypeBrand.builder().type(type).brand(brand).build();
 
-		// 테스트용 상품
-		item = Item.builder()
-			.id(10L)
-			.name("iPhone 15 Pro")
-			.price(BigDecimal.valueOf(1500000)) // 150만원
-			.itemStatus(ItemStatus.NONE)        // 타임딜 아님
-			.imageUrl("https://dummyimage.com/iphone.jpg")
-			.typeBrand(typeBrand)
-			.build();
-
-		// 재고
-		itemStock = ItemStock.builder()
-			.item(item)
-			.quantity(100)
-			.build();
-
-		// 테스트용 회원과 장바구니 객체 생성
 		cart = Cart.builder()
 			.member(Member.builder().id(memberId).build())
 			.build();
-		cart.setId(100L); // ID는 테스트용으로 수동 설정
+		cart.setId(100L);
+	}
 
-		// 장바구니에 iPhone 15 Pro를 2개 담은 항목 생성
-		cartItem = CartItem.of(cart, item, 2);
-		cartItem.setId(101L);
+	private Item createItem(Long id, String name, int price, ItemStatus status) {
+		return Item.builder()
+			.id(id)
+			.name(name)
+			.price(BigDecimal.valueOf(price))
+			.itemStatus(status)
+			.imageUrl("")
+			.typeBrand(sharedTypeBrand)
+			.build();
+	}
+
+	private CartItem createCartItem(Item item, int quantity) {
+		CartItem ci = CartItem.of(cart, item, quantity);
+		ci.setId(item.getId() * 10);
+		return ci;
+	}
+
+	private ItemStock createStock(Item item, int quantity) {
+		return ItemStock.builder().item(item).quantity(quantity).build();
+	}
+
+	private void givenCart(List<CartItem> items) {
+		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
+		given(cartItemRepository.findAllWithItemByCartId(cart.getId())).willReturn(items);
 	}
 
 	@Test
-	@DisplayName("장바구니 상품 조회")
-	void getCartWithNormalItem() {
-		// given: 장바구니에 일반 상품이 담겨 있고 재고가 충분한 상태
-		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
-		given(cartItemRepository.findAllByCartId(cart.getId())).willReturn(List.of(cartItem));
-		given(itemStockRepository.findByItemId(item.getId())).willReturn(Optional.of(itemStock));
+	void 장바구니_일반() {
+		Item item = createItem(10L, "iPhone", 1500000, ItemStatus.NONE);
+		CartItem ci = createCartItem(item, 2);
+		ItemStock stock = createStock(item, 100);
 
-		// when: 장바구니 조회 요청
+		givenCart(List.of(ci));
+		given(itemStockRepository.findAllByItemIdIn(List.of(item.getId()))).willReturn(List.of(stock));
+
 		CartFetchResponse result = cartService.getMyCart(memberId);
 
-		// then: 상품 수량, 가격, ID, 총합 정보가 정확히 응답되는지 검증
-		assertThat(result).isNotNull();
 		assertThat(result.cartId()).isEqualTo(cart.getId());
 		assertThat(result.items()).hasSize(1);
-		CartItemFetchResponse response = result.items().get(0);
-		assertThat(response.itemId()).isEqualTo(item.getId());
-		assertThat(response.quantity()).isEqualTo(2);
-		assertThat(result.cartTotalQuantity()).isEqualTo(2);
-		assertThat(result.cartTotalPrice()).isEqualTo(1500000 * 2);
+		CartItemFetchResponse res = result.items().get(0);
+		assertThat(res.itemId()).isEqualTo(item.getId());
+		assertThat(res.quantity()).isEqualTo(2);
+		assertThat(res.totalPrice()).isEqualTo(1500000 * 2);
 	}
 
 	@Test
-	@DisplayName("타임딜 상품 장바구니 조회")
-	void getCartWithTimeDealItem() {
-		// given: 타임딜 상태의 상품과 해당 타임딜 정보를 설정
-		item.changeItemStatus(ItemStatus.TIME_DEAL);
-
-		TimeDealItem timeDealItem = TimeDealItem.builder()
+	void 장바구니_타임딜() {
+		Item item = createItem(11L, "Z Fold", 2000000, ItemStatus.TIME_DEAL);
+		CartItem ci = createCartItem(item, 2);
+		ItemStock stock = createStock(item, 50);
+		TimeDealItem tdi = TimeDealItem.builder()
 			.item(item)
-			.price(BigDecimal.valueOf(1350000)) // 할인 가격
-			.timeDeal(TimeDeal.builder().discountRatio(10).build()) // 할인율
-			.build();
-
-		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
-		given(cartItemRepository.findAllByCartId(cart.getId())).willReturn(List.of(cartItem));
-		given(itemStockRepository.findByItemId(item.getId())).willReturn(Optional.of(itemStock));
-		given(timeDealItemRepository.findActiveTimeDealItemByItemId(item.getId())).willReturn(Optional.of(timeDealItem));
-
-		// when: 장바구니 조회
-		CartFetchResponse result = cartService.getMyCart(memberId);
-
-		// then: 할인 정보가 정확히 반영되어 있는지 검증
-		CartItemFetchResponse response = result.items().get(0);
-		assertThat(response.originalPrice()).isEqualTo(1500000);
-		assertThat(response.discountedPrice()).isEqualTo(1350000);
-		assertThat(response.isTimeDeal()).isTrue();
-		assertThat(response.discountRatio()).isEqualTo(10);
-		assertThat(response.totalPrice()).isEqualTo(1350000 * 2);
-	}
-
-	@Test
-	@DisplayName("품절 상품 장바구니 조회")
-	void getCartWithSoldOutItem() {
-		// given: 재고 수량이 0인 품절 상품 설정
-		itemStock = ItemStock.builder()
-			.item(item)
-			.quantity(0)
-			.build();
-
-		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
-		given(cartItemRepository.findAllByCartId(cart.getId())).willReturn(List.of(cartItem));
-		given(itemStockRepository.findByItemId(item.getId())).willReturn(Optional.of(itemStock));
-
-		// when: 장바구니 조회
-		CartFetchResponse result = cartService.getMyCart(memberId);
-
-		// then: 품절 상품의 표시 여부와 전체 합산 제외 여부 검증
-		CartItemFetchResponse response = result.items().get(0);
-
-		assertThat(response.itemId()).isEqualTo(item.getId());
-		assertThat(response.quantity()).isEqualTo(cartItem.getQuantity());
-		assertThat(response.isSoldOut()).isTrue(); // 품절 여부
-		assertThat(response.discountedPrice()).isEqualTo(item.getPrice().intValue());
-		assertThat(response.totalPrice()).isEqualTo(item.getPrice().intValue() * cartItem.getQuantity());
-
-		assertThat(result.cartTotalQuantity()).isEqualTo(0); // 품절 제외
-		assertThat(result.cartTotalPrice()).isEqualTo(0);    // 품절 제외
-	}
-
-	@Test
-	@DisplayName("혼합 상품 장바구니 조회")
-	void getCartWithMixedItems() {
-		// given: 일반 상품, 타임딜 상품, 품절 상품 각각 생성 및 mock 설정
-
-		// 일반 상품
-		Item normalItem = Item.builder()
-			.id(1L)
-			.name("노트북")
-			.price(BigDecimal.valueOf(1000000))
-			.itemStatus(ItemStatus.NONE)
-			.imageUrl("url")
-			.typeBrand(item.getTypeBrand())
-			.build();
-		CartItem normalCartItem = CartItem.of(cart, normalItem, 1);
-		ItemStock normalStock = ItemStock.builder().item(normalItem).quantity(10).build();
-
-		// 타임딜 상품
-		Item timeDealItem = Item.builder()
-			.id(2L)
-			.name("갤럭시 Z Fold")
-			.price(BigDecimal.valueOf(2000000))
-			.itemStatus(ItemStatus.TIME_DEAL)
-			.imageUrl("url")
-			.typeBrand(item.getTypeBrand())
-			.build();
-		CartItem timeDealCartItem = CartItem.of(cart, timeDealItem, 2);
-		ItemStock timeDealStock = ItemStock.builder().item(timeDealItem).quantity(5).build();
-		TimeDealItem timeDeal = TimeDealItem.builder()
-			.item(timeDealItem)
 			.price(BigDecimal.valueOf(1800000))
 			.timeDeal(TimeDeal.builder().discountRatio(10).build())
 			.build();
 
-		// 품절 상품
-		Item soldOutItem = Item.builder()
-			.id(3L)
-			.name("에어팟")
-			.price(BigDecimal.valueOf(500000))
-			.itemStatus(ItemStatus.NONE)
-			.imageUrl("url")
-			.typeBrand(item.getTypeBrand())
-			.build();
-		CartItem soldOutCartItem = CartItem.of(cart, soldOutItem, 1);
-		ItemStock soldOutStock = ItemStock.builder().item(soldOutItem).quantity(0).build();
+		givenCart(List.of(ci));
+		given(itemStockRepository.findAllByItemIdIn(List.of(item.getId()))).willReturn(List.of(stock));
+		given(timeDealItemRepository.findActiveTimeDealItemByItemId(item.getId())).willReturn(Optional.of(tdi));
 
-		// Mock 설정
-		given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
-		given(cartItemRepository.findAllByCartId(cart.getId()))
-			.willReturn(List.of(normalCartItem, timeDealCartItem, soldOutCartItem));
-		given(itemStockRepository.findByItemId(normalItem.getId())).willReturn(Optional.of(normalStock));
-		given(itemStockRepository.findByItemId(timeDealItem.getId())).willReturn(Optional.of(timeDealStock));
-		given(itemStockRepository.findByItemId(soldOutItem.getId())).willReturn(Optional.of(soldOutStock));
-		given(timeDealItemRepository.findActiveTimeDealItemByItemId(timeDealItem.getId())).willReturn(Optional.of(timeDeal));
+		CartItemFetchResponse res = cartService.getMyCart(memberId).items().get(0);
 
-		// when: 장바구니 조회
-		CartFetchResponse result = cartService.getMyCart(memberId);
-
-		// then: 항목 개수 확인
-		assertThat(result).isNotNull();
-		assertThat(result.items()).hasSize(3);
-
-		// 일반 상품 검증
-		CartItemFetchResponse normalRes = result.items().stream()
-			.filter(r -> r.itemId().equals(normalItem.getId()))
-			.findFirst().orElseThrow();
-		assertThat(normalRes.isTimeDeal()).isFalse();
-		assertThat(normalRes.isSoldOut()).isFalse();
-		assertThat(normalRes.totalPrice()).isEqualTo(1000000);
-
-		// 타임딜 상품 검증
-		CartItemFetchResponse timeDealRes = result.items().stream()
-			.filter(r -> r.itemId().equals(timeDealItem.getId()))
-			.findFirst().orElseThrow();
-		assertThat(timeDealRes.isTimeDeal()).isTrue();
-		assertThat(timeDealRes.isSoldOut()).isFalse();
-		assertThat(timeDealRes.discountedPrice()).isEqualTo(1800000);
-		assertThat(timeDealRes.totalPrice()).isEqualTo(1800000 * 2);
-
-		// 품절 상품 검증
-		CartItemFetchResponse soldOutRes = result.items().stream()
-			.filter(r -> r.itemId().equals(soldOutItem.getId()))
-			.findFirst().orElseThrow();
-		assertThat(soldOutRes.isSoldOut()).isTrue();
-		assertThat(soldOutRes.totalPrice()).isEqualTo(500000);
-
-		// 총합 검증 (품절 상품 제외)
-		int expectedQuantity = 1 + 2;
-		int expectedPrice = 1000000 + 1800000 * 2;
-		assertThat(result.cartTotalQuantity()).isEqualTo(expectedQuantity);
-		assertThat(result.cartTotalPrice()).isEqualTo(expectedPrice);
+		assertThat(res.isTimeDeal()).isTrue();
+		assertThat(res.discountedPrice()).isEqualTo(1800000);
+		assertThat(res.totalPrice()).isEqualTo(1800000 * 2);
 	}
 
+	@Test
+	void 장바구니_품절() {
+		Item item = createItem(12L, "에어팟", 500000, ItemStatus.NONE);
+		CartItem ci = createCartItem(item, 1);
+		ItemStock stock = createStock(item, 0);
+
+		givenCart(List.of(ci));
+		given(itemStockRepository.findAllByItemIdIn(List.of(item.getId()))).willReturn(List.of(stock));
+
+		CartItemFetchResponse res = cartService.getMyCart(memberId).items().get(0);
+
+		assertThat(res.isSoldOut()).isTrue();
+		assertThat(res.totalPrice()).isEqualTo(500000);
+		assertThat(cartService.getMyCart(memberId).cartTotalPrice()).isEqualTo(0);
+	}
+
+	@Test
+	void 장바구니_혼합() {
+		Item normal = createItem(1L, "노트북", 1000000, ItemStatus.NONE);
+		Item timeDeal = createItem(2L, "Z Fold", 2000000, ItemStatus.TIME_DEAL);
+		Item soldOut = createItem(3L, "에어팟", 500000, ItemStatus.NONE);
+
+		CartItem ci1 = createCartItem(normal, 1);
+		CartItem ci2 = createCartItem(timeDeal, 2);
+		CartItem ci3 = createCartItem(soldOut, 1);
+
+		ItemStock s1 = createStock(normal, 10);
+		ItemStock s2 = createStock(timeDeal, 5);
+		ItemStock s3 = createStock(soldOut, 0);
+
+		TimeDealItem td = TimeDealItem.builder()
+			.item(timeDeal)
+			.price(BigDecimal.valueOf(1800000))
+			.timeDeal(TimeDeal.builder().discountRatio(10).build())
+			.build();
+
+		givenCart(List.of(ci1, ci2, ci3));
+		given(itemStockRepository.findAllByItemIdIn(List.of(1L, 2L, 3L)))
+			.willReturn(List.of(s1, s2, s3));
+		given(timeDealItemRepository.findActiveTimeDealItemByItemId(2L))
+			.willReturn(Optional.of(td));
+
+		CartFetchResponse result = cartService.getMyCart(memberId);
+		assertThat(result.items()).hasSize(3);
+		assertThat(result.cartTotalQuantity()).isEqualTo(3);
+		assertThat(result.cartTotalPrice()).isEqualTo(1000000 + 1800000 * 2);
+	}
 }

--- a/src/test/java/com/jelly/zzirit/domain/order/domain/fixture/OrderFixture.java
+++ b/src/test/java/com/jelly/zzirit/domain/order/domain/fixture/OrderFixture.java
@@ -3,6 +3,7 @@ package com.jelly.zzirit.domain.order.domain.fixture;
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.UUID;
 
 import com.jelly.zzirit.domain.member.entity.Member;
 import com.jelly.zzirit.domain.order.entity.Order;
@@ -31,9 +32,8 @@ public class OrderFixture {
     }
 
     private static String generateUniqueOrderNumber() {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd-HHmmss");
-        String timestamp = sdf.format(new Date());
-
-        return "order-" + timestamp + "-" + (System.currentTimeMillis() % 1000000);  // 밀리초 단위로 유니크 값 추가
+        String datePart = new SimpleDateFormat("yyyyMMdd").format(new Date()); // 8자
+        long nanoPart = System.nanoTime() % 1_000_000_000; // 최대 9자리
+        return "order-" + datePart + "-" + nanoPart; // 총 길이: 최대 24~28자
     }
 }


### PR DESCRIPTION
<!-- PR 제목 -> 최종 커밋 메시지로 사용됩니다 -->
<!-- 형식: <타입>: <간결하고 명확한 변경 요약> (#<PR 번호>) -->
<!-- ex) Feat: 로그인 기능 구현 (#123) -->
<!-- 타입 예시: Feat | Fix | Refactor | Docs | Test | Chore -->

## 🐛 관련 이슈
<!--
이 PR로 해결되는 이슈 번호를 Close #번호 형태로 작성해주세요.
예:
- Closes #123
-->
> Closes #165

## 💻 작업 내용
<!--
해당 PR에서 작업한 내용, 변경 사항 등을 작성해주세요.
예:
- 소셜 로그인 기능 추가 (Google, Naver)
- 로그인 예외 처리 방식 수정
- 테스트 코드 보완 및 리팩토링
-->
- CartService 테스트 코드 리팩토링 및 중복 제거
- QueryDSL fetch join을 통해 장바구니 조회 시 발생하던 N+1 문제 해결
- getMyCart 내부 로직을 역할 단위로 분리하여 가독성 개선
- 응답 DTO 생성 로직을 `CartItemMapper`로 분리하여 책임 명확화
- addItemToCart 메서드의 N+1 문제 해결 및 테스트 추가
- mapper 구조 개선
- Repository 어노테이션 정리 및 코드 포맷 정리
- UniqueOrderNumber 중복 문제 해결 (UUID 일부를 사용해 30자 제한 대응)

## ✅ 체크 리스트
<!-- 완료된 항목에 한해서 [ ] 안에 x를 적어주세요. --> 
- [x] 적절한 작업 단위로 커밋을 수행했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 풀 리퀘스트 제목에 컨벤션을 적용했습니다.
- [x] 테스트 코드를 작성했습니다.
- [x] Assignees에 나를 할당했습니다.

## ⚠️ 주의 사항
<!--
리뷰어가 확인 전에 꼭 알아야 할 변경사항이나 주의사항이 있다면 작성해주세요.
예:
- DB 스키마 변경이 포함되어 있어 배포 전 마이그레이션 필요
- `.env` 설정값이 추가되어야 정상 동작합니다
- 주의 사항이 없을 시: _No specific notes_
-->
- orderNumber는 DB 제약조건(length 30, unique)을 만족하도록 생성 로직 수정됨

## 🗨️ 리뷰 요구 사항
<!--
리뷰어가 중점적으로 확인해줬으면 하는 부분이 있다면 작성해주세요.
예:
- 새로운 정렬 로직의 성능이 괜찮은지 확인 부탁드립니다
- 컨트롤러에서 비즈니스 로직을 얼마나 포함해도 될지 의견 부탁드립니다
- 리뷰 요구 사항이 없을 시: _Nothing in particular_
-->
- CartService 리팩토링 방향과 책임 분리 방식이 적절한지 확인 부탁드려요
- QueryDSL fetch join 구문의 성능상 이슈나 개선점이 있다면 의견 부탁드려요